### PR TITLE
Add support for temporary retry policies

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -77,9 +77,40 @@ jobs:
           with:
             name: author
             path: target/author
+  sonar:
+    name: sonar
+    runs-on: ubuntu-18.04
+    steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: Set up JDK 11
+          uses: actions/setup-java@v1
+          with:
+            java-version: 11
+        - name: Cache SonarCloud packages
+          uses: actions/cache@v1
+          with:
+            path: ~/.sonar/cache
+            key: ${{ runner.os }}-sonar
+            restore-keys: ${{ runner.os }}-sonar
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
+        - run: ./dev-support/checks/sonar.sh
+          if: github.event_name != 'pull_request'
+          env:
+            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   unit:
     name: unit
     runs-on: ubuntu-18.04
+    needs: [sonar, build]
     steps:
         - uses: actions/checkout@master
         - name: Cache for maven dependencies
@@ -90,11 +121,6 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
-        - run: ./dev-support/checks/sonar.sh
-          if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
-          env:
-            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - run: ./dev-support/checks/unit.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -20,4 +20,4 @@ if [ ! "$SONAR_TOKEN" ]; then
   echo "SONAR_TOKEN environment variable should be set"
   exit 1
 fi
-mvn -B verify -DskipShade -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-ratis
+mvn -B verify -DskipShade -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=softgitron -Dsonar.projectKey=softgitron_incubator-ratis

--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClient.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClient.java
@@ -69,6 +69,21 @@ public interface RaftClient extends Closeable {
   /** @return the {@link DataStreamApi}. */
   DataStreamApi getDataStreamApi();
 
+  /** @return current raft properties {@link RaftProperties}. */
+  RaftProperties getProperties();
+
+  /** @return current retry policy {@link RetryPolicy}. */
+  RetryPolicy getRetryPolicy();
+
+  /** @return new client with custom properties {@link RaftClient}. */
+  RaftClient getNewInstanceWithOptions(RaftProperties newProperties);
+
+  /** @return new client with custom retry policy {@link RaftClient}. */
+  RaftClient getNewInstanceWithOptions(RetryPolicy newRetryPolicy);
+
+  /** @return new client with custom properties and retry policy {@link RaftClient}. */
+  RaftClient getNewInstanceWithOptions(RaftProperties newProperties, RetryPolicy newRetryPolicy);
+
   /** @return a {@link Builder}. */
   static Builder newBuilder() {
     return new Builder();

--- a/ratis-test/src/test/java/org/apache/ratis/client/TestClientImpl.java
+++ b/ratis-test/src/test/java/org/apache/ratis/client/TestClientImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.client;
+
+
+import org.apache.ratis.BaseTest;
+import org.apache.ratis.RaftConfigKeys;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.grpc.GrpcFactory;
+import org.apache.ratis.protocol.*;
+import org.apache.ratis.retry.RetryPolicies;
+import org.apache.ratis.retry.RetryPolicy;
+import org.apache.ratis.rpc.SupportedRpcType;
+import org.apache.ratis.util.TimeDuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/** Test {@link org.apache.ratis.client.impl.RaftClientImpl}. */
+public class TestClientImpl extends BaseTest {
+  // Sample group
+  private static final List<RaftPeer> PEERS = new ArrayList<>(3);
+  static {
+    PEERS.add(RaftPeer.newBuilder().setId("n1").setAddress("127.0.0.1:6000").build());
+    PEERS.add(RaftPeer.newBuilder().setId("n2").setAddress("127.0.0.1:6001").build());
+    PEERS.add(RaftPeer.newBuilder().setId("n3").setAddress("127.0.0.1:6002").build());
+  }
+  private static final UUID CLUSTER_GROUP_ID = UUID.fromString("02511d47-d67c-49a3-9011-abb3109a44c1");
+  private static final RaftGroup RAFT_GROUP = RaftGroup.valueOf(
+          RaftGroupId.valueOf(CLUSTER_GROUP_ID), PEERS);
+
+  @Test
+  public void testGetNewInstance() throws Exception {
+    RaftProperties raftProperties = new RaftProperties();
+    RaftConfigKeys.Rpc.setType(raftProperties, SupportedRpcType.GRPC);
+    RetryPolicy retryPolicy = RetryPolicies.retryUpToMaximumCountWithFixedSleep(10,
+            TimeDuration.valueOf(1000, TimeUnit.MILLISECONDS));
+
+    RaftClient raftClient = buildNewClient(raftProperties, retryPolicy);
+    Assert.assertEquals(raftProperties, raftClient.getProperties());
+    Assert.assertEquals(retryPolicy, raftClient.getRetryPolicy());
+
+    RaftProperties newRaftProperties = new RaftProperties();
+    RaftConfigKeys.Rpc.setType(newRaftProperties, SupportedRpcType.NETTY);
+    RetryPolicy newRetryPolicy = RetryPolicies.retryUpToMaximumCountWithFixedSleep(100,
+            TimeDuration.valueOf(100, TimeUnit.MILLISECONDS));
+
+    RaftClient newRaftClient = raftClient.getNewInstanceWithOptions(newRaftProperties, newRetryPolicy);
+    Assert.assertEquals(newRaftProperties, newRaftClient.getProperties());
+    Assert.assertEquals(newRetryPolicy, newRaftClient.getRetryPolicy());
+
+    // Check that APIs have fresh objects
+    Assert.assertNotEquals(raftClient.admin(), newRaftClient.admin());
+    Assert.assertNotEquals(raftClient.async(), newRaftClient.async());
+    Assert.assertNotEquals(raftClient.getDataStreamApi(), newRaftClient.getDataStreamApi());
+    Assert.assertNotEquals(raftClient.getMessageStreamApi(), newRaftClient.getMessageStreamApi());
+
+    newRaftClient = raftClient.getNewInstanceWithOptions(newRaftProperties);
+    Assert.assertEquals(newRaftProperties, newRaftClient.getProperties());
+    Assert.assertEquals(retryPolicy, newRaftClient.getRetryPolicy());
+
+    newRaftClient = raftClient.getNewInstanceWithOptions(newRetryPolicy);
+    Assert.assertEquals(raftProperties, newRaftClient.getProperties());
+    Assert.assertEquals(newRetryPolicy, newRaftClient.getRetryPolicy());
+  }
+  private RaftClient buildNewClient(RaftProperties raftProperties, RetryPolicy retryPolicy) {
+    RaftClient.Builder builder = RaftClient.newBuilder()
+            .setProperties(raftProperties).
+            setRetryPolicy(retryPolicy)
+            .setRaftGroup(RAFT_GROUP)
+            .setClientRpc(
+                    new GrpcFactory(new Parameters())
+                            .newRaftClientRpc(ClientId.randomId(), raftProperties));
+    return builder.build();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add new methods for forking Raft client implementation in order to make setting of temporary retry policies easier.

## How was this patch tested?

Patch is tested using unit tests.
